### PR TITLE
Improve animation

### DIFF
--- a/example/app/(tabs)/misc.tsx
+++ b/example/app/(tabs)/misc.tsx
@@ -4,36 +4,33 @@ import { Skeleton } from 'react-native-skia-skeleton';
 export default function Misc() {
   return (
     <ScrollView contentContainerStyle={styles.container}>
+      <Skeleton loading={true} bones={[{ width: 300, height: 100 }]} />
       <Skeleton
         loading={true}
-        bones={[{ dimensions: { width: 300, height: 100 } }]}
-      />
-      <Skeleton
-        loading={true}
-        bones={[{ dimensions: { width: 300, height: 100 } }]}
+        bones={[{ width: 300, height: 100 }]}
         animation={{ duration: 1500, direction: 'rightToLeft', reverse: false }}
       />
       <Skeleton
         loading={true}
-        bones={[{ dimensions: { width: 300, height: 100 } }]}
+        bones={[{ width: 300, height: 100 }]}
         animation={{ duration: 1200, direction: 'leftToRight', reverse: false }}
         colors={{ background: '#77A6B6', shimmer: '#9DC3C2' }}
       />
       <Skeleton
         loading={true}
-        bones={[{ dimensions: { width: 300, height: 100 } }]}
+        bones={[{ width: 300, height: 100 }]}
         animation={{ duration: 1200, direction: 'topToBottom', reverse: false }}
         colors={{ background: '#ffb422', shimmer: '#ffec36' }}
       />
       <Skeleton
         loading={true}
-        bones={[{ dimensions: { width: 300, height: 100 } }]}
+        bones={[{ width: 300, height: 100 }]}
         animation={{ duration: 1200, direction: 'bottomToTop', reverse: false }}
         colors={{ background: '#ffb422', shimmer: '#ffec36' }}
       />
       <Skeleton
         loading={true}
-        bones={[{ dimensions: { width: 300, height: 100 } }]}
+        bones={[{ width: 300, height: 100 }]}
         animation={{ duration: 2000, direction: 'leftToRight', reverse: true }}
         colors={{ background: '#00b422', shimmer: '#ff0036' }}
       />

--- a/example/components/Card.tsx
+++ b/example/components/Card.tsx
@@ -35,13 +35,12 @@ export const Card: React.FC<{ loading: boolean }> = ({ loading }) => {
           containerStyle={styles.info}
           bones={[
             {
-              display: 'flex',
-              width: '100%',
+              width: '80%',
               height: 16,
               borderRadius: 4,
             },
             {
-              width: 200,
+              width: '80%',
               height: 16,
               borderRadius: 4,
               marginTop: 4,
@@ -119,6 +118,7 @@ const styles = StyleSheet.create({
     marginLeft: 12,
     display: 'flex',
     alignItems: 'flex-start',
+    width: '100%',
   },
   name: {
     fontWeight: '600',

--- a/example/components/Card.tsx
+++ b/example/components/Card.tsx
@@ -19,8 +19,9 @@ export const Card: React.FC<{ loading: boolean }> = ({ loading }) => {
           loading={loading}
           bones={[
             {
-              dimensions: { width: 48, height: 48 },
-              border: { borderRadius: 24 },
+              width: 48,
+              height: 48,
+              borderRadius: 24,
             },
           ]}
         >
@@ -34,13 +35,16 @@ export const Card: React.FC<{ loading: boolean }> = ({ loading }) => {
           containerStyle={styles.info}
           bones={[
             {
-              dimensions: { width: 200, height: 16 },
-              border: { borderRadius: 4 },
+              display: 'flex',
+              width: '100%',
+              height: 16,
+              borderRadius: 4,
             },
             {
-              dimensions: { width: 200, height: 16 },
-              border: { borderRadius: 4 },
-              margins: { marginTop: 4 },
+              width: 200,
+              height: 16,
+              borderRadius: 4,
+              marginTop: 4,
             },
           ]}
         >
@@ -53,23 +57,27 @@ export const Card: React.FC<{ loading: boolean }> = ({ loading }) => {
         containerStyle={styles.body}
         bones={[
           {
-            dimensions: { width: width - cardMargins - 32, height: 16 },
-            border: { borderRadius: 4 },
+            width: width - cardMargins - 32,
+            height: 16,
+            borderRadius: 4,
           },
           {
-            dimensions: { width: 200, height: 16 },
-            border: { borderRadius: 4 },
-            margins: { marginTop: 4 },
+            width: 200,
+            height: 16,
+            borderRadius: 4,
+            marginTop: 4,
           },
           {
-            dimensions: { width: width - cardMargins - 32, height: 16 },
-            border: { borderRadius: 4 },
-            margins: { marginTop: 10 },
+            width: width - cardMargins - 32,
+            height: 16,
+            borderRadius: 4,
+            marginTop: 10,
           },
           {
-            dimensions: { width: 200, height: 16 },
-            border: { borderRadius: 4 },
-            margins: { marginTop: 4 },
+            width: 200,
+            height: 16,
+            borderRadius: 4,
+            marginTop: 4,
           },
         ]}
       >

--- a/src/Bone.tsx
+++ b/src/Bone.tsx
@@ -84,9 +84,9 @@ export const Bone: React.FC<BoneProps> = ({ layout, colors, animation }) => {
       animation.direction === 'rightToLeft'
   );
 
-  const gradientEnd = useDerivedValue(() =>
-    isHorizontal ? vec(dimensions.width, 0) : vec(0, dimensions.height)
-  );
+  const gradientEnd = isHorizontal.value
+    ? vec(dimensions.width, 0)
+    : vec(0, dimensions.height);
 
   const shimmer = useAnimatedStyle(() =>
     isHorizontal.value


### PR DESCRIPTION
Improve animation so that it doesn't depend on dimensions passed from the outside of the skeleton.

## Description
Now Bone calculate the dimensions using an onLayout callback. This sets the animation values so that the dimensions are dynamic. This enable the library to pass a ViewStyle to the bone, that could use flex layouts. This will let me explore the possibility to add a children prop to do nested skeleton layout.

## Motivation and Context
Skeleton should be able to be nested in the layout.

## How Has This Been Tested?
Example app

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [X] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X ] All new and existing tests passed :white_check_mark:.
