### PR TITLE
Automatic layout

### DIFF
--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -1,40 +1,30 @@
-import { ScrollView, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useEffect, useState } from 'react';
+import { Button, ScrollView, StyleSheet } from 'react-native';
+import { useState } from 'react';
 import { CardMixedSkeleton } from '../../components/CardMixedSkeleton';
 import { CardFullLayoutSkeleton } from '../../components/CardFullLayoutSkeleton';
+import { CardAutomaticSkeleton } from '../../components/CardAutomaticSkeleton';
 
 export default function Index() {
   const [loadingCard, setLoadingCard] = useState(true);
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setLoadingCard((prevLoadingCard) => !prevLoadingCard);
-    }, 4000);
-
-    return () => clearInterval(interval);
-  }, []);
-
   return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView contentContainerStyle={styles.scrollView}>
-        <CardMixedSkeleton loading={loadingCard} />
-        <CardFullLayoutSkeleton loading={loadingCard} />
-      </ScrollView>
-    </SafeAreaView>
+    <ScrollView contentContainerStyle={styles.scrollView}>
+      <Button onPress={() => setLoadingCard(!loadingCard)} title={'Trigger'} />
+      <CardMixedSkeleton loading={loadingCard} />
+      <CardFullLayoutSkeleton loading={loadingCard} />
+      <CardAutomaticSkeleton loading={loadingCard} />
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  container: {},
+  scrollView: {
     flex: 1,
     backgroundColor: '#DDDDDD',
-  },
-  scrollView: {
     gap: 10,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#DDDDDD',
-    margin: 10,
+    padding: 10,
   },
 });

--- a/example/components/CardAutomaticSkeleton.tsx
+++ b/example/components/CardAutomaticSkeleton.tsx
@@ -26,14 +26,9 @@ export const CardAutomaticSkeleton: React.FC<{ loading: boolean }> = ({
           </View>
         </View>
         <View style={styles.body}>
+          <Text style={styles.text}>Just finished the first draft!</Text>
           <Text style={styles.text}>
-            Just finished the first draft of the new onboarding flow. Can’t wait
-            to share it!
-          </Text>
-          <Text style={styles.text}>
-            Also, huge thanks to the team for the feedback during our last
-            review. It was a pleasure to collaborate on this kind of task that
-            give me such a boost.
+            Huge thanks to the team for the feedback!
           </Text>
         </View>
       </View>

--- a/example/components/CardAutomaticSkeleton.tsx
+++ b/example/components/CardAutomaticSkeleton.tsx
@@ -32,7 +32,8 @@ export const CardAutomaticSkeleton: React.FC<{ loading: boolean }> = ({
           </Text>
           <Text style={styles.text}>
             Also, huge thanks to the team for the feedback during our last
-            review.
+            review. It was a pleasure to collaborate on this kind of task that
+            give me such a boost.
           </Text>
         </View>
       </View>
@@ -42,7 +43,6 @@ export const CardAutomaticSkeleton: React.FC<{ loading: boolean }> = ({
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     width: '100%',
   },
   card: {
@@ -53,7 +53,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 10,
     elevation: 3,
-    marginBottom: 16,
   },
   header: {
     flexDirection: 'row',
@@ -71,15 +70,20 @@ const styles = StyleSheet.create({
     display: 'flex',
     alignItems: 'flex-start',
     width: '100%',
+    gap: 4,
   },
   name: {
     fontWeight: '600',
     fontSize: 16,
     color: '#111',
+    width: '80%',
+    height: 16,
   },
   subtitle: {
     fontSize: 14,
     color: '#666',
+    width: '80%',
+    height: 16,
   },
   body: {
     marginTop: 8,
@@ -88,5 +92,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#333',
     marginBottom: 6,
+    width: '80%',
+    height: 14,
   },
 });

--- a/example/components/CardAutomaticSkeleton.tsx
+++ b/example/components/CardAutomaticSkeleton.tsx
@@ -1,0 +1,92 @@
+import { Skeleton } from 'react-native-skia-skeleton';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+
+export const CardAutomaticSkeleton: React.FC<{ loading: boolean }> = ({
+  loading,
+}) => {
+  return (
+    <Skeleton
+      colors={{
+        background: '#C1C4E9',
+        shimmer: '#F1CEF7',
+      }}
+      containerStyle={styles.container}
+      loading={loading}
+    >
+      <View style={styles.card}>
+        <View style={styles.header}>
+          <Image
+            source={{ uri: 'https://i.pravatar.cc/100' }}
+            style={styles.avatar}
+          />
+          <View style={styles.info}>
+            <Text style={styles.name}>Jane Doe</Text>
+            <Text style={styles.subtitle}>UI Designer</Text>
+          </View>
+        </View>
+        <View style={styles.body}>
+          <Text style={styles.text}>
+            Just finished the first draft of the new onboarding flow. Can’t wait
+            to share it!
+          </Text>
+          <Text style={styles.text}>
+            Also, huge thanks to the team for the feedback during our last
+            review.
+          </Text>
+        </View>
+      </View>
+    </Skeleton>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+  },
+  card: {
+    backgroundColor: '#FFF',
+    padding: 16,
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    elevation: 3,
+    marginBottom: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: '#EEE',
+  },
+  info: {
+    marginLeft: 12,
+    display: 'flex',
+    alignItems: 'flex-start',
+    width: '100%',
+  },
+  name: {
+    fontWeight: '600',
+    fontSize: 16,
+    color: '#111',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#666',
+  },
+  body: {
+    marginTop: 8,
+  },
+  text: {
+    fontSize: 14,
+    color: '#333',
+    marginBottom: 6,
+  },
+});

--- a/example/components/CardFullLayoutSkeleton.tsx
+++ b/example/components/CardFullLayoutSkeleton.tsx
@@ -18,7 +18,6 @@ export const CardFullLayoutSkeleton: React.FC<{ loading: boolean }> = ({
           key: 'root',
           style: {
             display: 'flex',
-            flex: 1,
             justifyContent: 'center',
             alignItems: 'center',
             gap: 10,
@@ -150,8 +149,8 @@ export const CardFullLayoutSkeleton: React.FC<{ loading: boolean }> = ({
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     width: '100%',
+    display: 'flex',
   },
   card: {
     backgroundColor: '#FFF',
@@ -161,7 +160,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 10,
     elevation: 3,
-    marginBottom: 16,
   },
   header: {
     flexDirection: 'row',

--- a/example/components/CardMixedSkeleton.tsx
+++ b/example/components/CardMixedSkeleton.tsx
@@ -117,7 +117,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 10,
     elevation: 3,
-    marginBottom: 16,
   },
   header: {
     flexDirection: 'row',

--- a/src/Bone/Bone.tsx
+++ b/src/Bone/Bone.tsx
@@ -22,13 +22,7 @@ export const Bone: React.FC<BoneProps> = ({ features }) => {
 
   return (
     <View
-      style={[
-        styles.container,
-        style,
-        {
-          backgroundColor: colors.background,
-        },
-      ]}
+      style={[styles.container, style, { backgroundColor: colors.background }]}
       onLayout={onLayout}
     >
       <Animated.View style={[StyleSheet.absoluteFill, boneAnimation]}>

--- a/src/Bone/useBoneAnimation.ts
+++ b/src/Bone/useBoneAnimation.ts
@@ -45,11 +45,13 @@ export const useBoneAnimation = (animation: BoneAnimation) => {
     const initialPosition =
       getInitialPosition[animation.direction](boneDimensions);
 
-    animatedValue.value = initialPosition;
-    animatedValue.value = withRepeat(
-      withTiming(-initialPosition, { duration: animation.duration }),
-      -1,
-      animation.reverse
+    animatedValue.set(() => initialPosition);
+    animatedValue.set(() =>
+      withRepeat(
+        withTiming(-initialPosition, { duration: animation.duration }),
+        -1,
+        animation.reverse
+      )
     );
   }, [boneDimensions, animatedValue, animation]);
 
@@ -60,12 +62,12 @@ export const useBoneAnimation = (animation: BoneAnimation) => {
   );
 
   const boneAnimation = useAnimatedStyle(() =>
-    isHorizontal.value
+    isHorizontal.get()
       ? { transform: [{ translateX: animatedValue.value }] }
       : { transform: [{ translateY: animatedValue.value }] }
   );
 
-  const boneGradientEnd = isHorizontal.value
+  const boneGradientEnd = isHorizontal.get()
     ? vec(boneDimensions.width, 0)
     : vec(0, boneDimensions.height);
 

--- a/src/Bones/Bones.tsx
+++ b/src/Bones/Bones.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { type StyleProp, StyleSheet, View, type ViewStyle } from 'react-native';
-import { Bone } from 'react-native-skia-skeleton';
 import type { BonesFeatures, BonesLayout } from './BonesFeatures';
+import { Bone } from '../Bone/Bone';
 
 type BonesProps = {
   bonesFeatures: BonesFeatures;

--- a/src/Bones/useBoneFeatures.ts
+++ b/src/Bones/useBoneFeatures.ts
@@ -1,0 +1,50 @@
+import React, { Children, type ReactElement, type ReactNode } from 'react';
+import type { BonesLayout } from './BonesFeatures';
+import type { BoneStyle } from '../Bone/BoneFeatures';
+
+const calculateBonesLayout = (
+  bones: BonesLayout[],
+  children?: ReactNode
+): BonesLayout[] => {
+  if (!children) {
+    return bones;
+  }
+
+  return (
+    Children.map(children, (child) => {
+      if (!React.isValidElement(child)) {
+        return null;
+      }
+
+      const element = child as ReactElement<{
+        style?: BoneStyle;
+        children?: ReactNode;
+      }>;
+
+      const layoutEntry: BonesLayout = {
+        style: element.props?.style ?? {},
+      };
+
+      if (element.props?.children) {
+        layoutEntry.children = calculateBonesLayout([], element.props.children);
+      }
+
+      return layoutEntry;
+    })?.filter(Boolean) ?? []
+  );
+};
+
+export const useBoneFeatures = (
+  bones?: BonesLayout[],
+  children?: ReactNode
+) => {
+  if (bones && bones.length > 0) {
+    return bones;
+  }
+
+  const bonesLayouts = calculateBonesLayout([], children);
+
+  console.log(JSON.stringify(bonesLayouts));
+
+  return bonesLayouts;
+};

--- a/src/Bones/useBoneFeatures.ts
+++ b/src/Bones/useBoneFeatures.ts
@@ -42,9 +42,5 @@ export const useBoneFeatures = (
     return bones;
   }
 
-  const bonesLayouts = calculateBonesLayout([], children);
-
-  console.log(JSON.stringify(bonesLayouts));
-
-  return bonesLayouts;
+  return calculateBonesLayout([], children);
 };

--- a/src/Skeleton/Content.tsx
+++ b/src/Skeleton/Content.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { type ViewStyle } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 
-export const Content: React.FC<{
+interface ContentProps {
   containerStyle?: ViewStyle;
   children: React.ReactNode;
-}> = ({ containerStyle, children }) => (
+}
+
+export const Content: React.FC<ContentProps> = ({
+  containerStyle,
+  children,
+}) => (
   <Animated.View entering={FadeIn} style={containerStyle}>
     {children}
   </Animated.View>

--- a/src/Skeleton/Skeleton.tsx
+++ b/src/Skeleton/Skeleton.tsx
@@ -5,10 +5,11 @@ import { Bones } from '../Bones/Bones';
 import { Content } from './Content';
 import type { BonesLayout } from '../Bones/BonesFeatures';
 import { defaultAnimation, defaultColors } from './defaults';
+import { useBoneFeatures } from '../Bones/useBoneFeatures';
 
 type SkeletonProps = {
   loading: boolean;
-  bones: BonesLayout[];
+  bones?: BonesLayout[];
   containerStyle?: ViewStyle;
   colors?: BoneColors;
   animation?: BoneAnimation;
@@ -22,16 +23,19 @@ export const Skeleton: React.FC<SkeletonProps> = ({
   colors = defaultColors,
   animation = defaultAnimation,
   children,
-}) =>
-  loading ? (
+}) => {
+  const calculatedBones = useBoneFeatures(bones, children);
+
+  return loading ? (
     <Bones
       bonesFeatures={{
         colors,
         animation,
-        layout: bones,
+        layout: calculatedBones,
       }}
       containerStyle={containerStyle}
     />
   ) : (
     <Content containerStyle={containerStyle}>{children}</Content>
   );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import { Bone } from './Bone/Bone';
 import { Skeleton } from './Skeleton/Skeleton';
 
-export { Bone, Skeleton };
+export { Skeleton };


### PR DESCRIPTION
Generate automatic layout from children of skeleton.

## Description
This new feature will create the skeleton bones from the children layout. The useBonesFeatures will loop recursively through the children and extract the styles from each one of them. These styles are used to create a `BoneLayout[]` used to create the skeleton.

This has a limitation: only views with explicit dimensions can be used with this skeleton mode. This is a consequence of the fact that some views doesn't render any size if they don't have their content (eg. `Text`) , and in Bone we don't propagate their content.

## Motivation and Context
Give a third option to setup a Skeleton

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [X] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/ID3TagEditor/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.
